### PR TITLE
:bug: fix: flat config for react hooks instead of extends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-jsx-a11y": ">=6.10.2",
         "eslint-plugin-prettier": ">=5.2.1",
         "eslint-plugin-react": ">=7.37.3",
-        "eslint-plugin-react-hooks": ">=6.1.1",
+        "eslint-plugin-react-hooks": ">=7.0.0",
         "eslint-plugin-storybook": ">=0.11.2",
         "typescript-eslint": ">=8.19.0"
       },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-prettier": ">=9.0.0",
     "eslint-plugin-prettier": ">=5.2.1",
     "eslint-plugin-react": ">=7.37.3",
-    "eslint-plugin-react-hooks": ">=6.1.1",
+    "eslint-plugin-react-hooks": ">=7.0.0",
     "eslint-plugin-storybook": ">=0.11.2",
     "typescript-eslint": ">=8.19.0"
   },

--- a/src/react.js
+++ b/src/react.js
@@ -4,6 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 
 const react = [
   jsxA11y.flatConfigs.recommended,
+  reactHooks.configs.flat.recommended,
   {
     name: "react/recommended",
     ...reactPlugin.configs.flat.recommended,
@@ -11,11 +12,6 @@ const react = [
   {
     name: "react/jsx-runtime",
     ...reactPlugin.configs.flat["jsx-runtime"],
-  },
-  {
-    name: "react-hooks/recommended",
-    plugins: {"react-hooks": reactHooks},
-    ...reactHooks.configs.flat.recommended,
   },
 ];
 

--- a/src/react.js
+++ b/src/react.js
@@ -15,7 +15,7 @@ const react = [
   {
     name: "react-hooks/recommended",
     plugins: {"react-hooks": reactHooks},
-    extends: ['react-hooks/recommended'],
+    ...reactHooks.configs.flat.recommended,
   },
 ];
 


### PR DESCRIPTION
Encountered an issue in one of our newer project (open-dms) wherein we got the error highlighted below. This should fix the issue.
 
```
julian@arch ~/dev/open-dms/src/opendms/frontend (issue/eslint)> npm run lint

> frontend@0.0.0 lint
> eslint .


Oops! Something went wrong! :(

ESLint: 9.39.2

A config object is using the "extends" key, which is not supported in flat config system.

Instead of "extends", you can include config objects that you'd like to extend from directly in the flat config array.

If you're using "extends" in your config file, please see the following:
https://eslint.org/docs/latest/use/configure/migration-guide#predefined-and-shareable-configs

If you're not using "extends" directly (it may be coming from a plugin), please see the following:
https://eslint.org/docs/latest/use/configure/migration-guide#using-eslintrc-configs-in-flat-config
```